### PR TITLE
Move setup action to root dir

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-node@v3.6.0
         with:
           node-version: 18.x
-      - uses: ./setup
+      - uses: ./
         with:
           tag: ${{ matrix.version }}
       - run: mass help

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ A collection of GitHub Actions for interacting with [Massdriver](https://massdri
 
 ## Setup
 
-Use this action to set up the [Massdriver CLI](https://github.com/massdriver-cloud/mass) for use in your workflows.
-This is a prerequisite for using any of the below GitHub Actions.
+Use the root action to set up the [Massdriver CLI](https://github.com/massdriver-cloud/mass) for use in your workflows.
 
 ```yaml
 jobs:
@@ -13,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install Massdriver CLI
-        uses: massdriver-cloud/actions/setup@v3
+        uses: massdriver-cloud/actions@v3
       - name: Use Massdriver CLI
         run: mass help
 ```
@@ -41,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Massdriver CLI
-        uses: massdriver-cloud/actions/setup@v3
+        uses: massdriver-cloud/actions@v3
       - name: Deploy App
         uses: massdriver-cloud/actions/app_deploy@v3
         with:
@@ -65,7 +64,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Massdriver CLI
-        uses: massdriver-cloud/actions/setup@v3
+        uses: massdriver-cloud/actions@v3
       - name: Patch App
         uses: massdriver-cloud/actions/app_patch@v3
         with:
@@ -91,7 +90,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Massdriver CLI
-        uses: massdriver-cloud/actions/setup@v3
+        uses: massdriver-cloud/actions@v3
       - name: Publish Bundle
         uses: massdriver-cloud/actions/bundle_publish@v3
 ```
@@ -110,7 +109,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install Massdriver CLI
-        uses: massdriver-cloud/actions/setup@v3
+        uses: massdriver-cloud/actions@v3
       - name: Push Image
         uses: massdriver-cloud/actions/image_push@v3
         with:

--- a/action.yml
+++ b/action.yml
@@ -16,4 +16,4 @@ inputs:
     default: ${{ github.token }}
 runs:
   using: 'node16'
-  main: '../dist/setup/index.js'
+  main: 'dist/setup/index.js'

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
-name: 'Setup Massdriver CLI'
+name: 'Massdriver'
 description: |
-  Deprecated. Use the root action `massdriver-cloud` instead.
+  Set up the Massdriver CLI.
 author: 'Massdriver, Inc.'
 inputs:
   tag:


### PR DESCRIPTION
In order to publish to GH Marketplace, we need to have an action.yml in the root dir.

Let's take github.com/actions/cache as an example. The base "cache" action is in the root dir, and the additional "save" and "restore" actions are under /save and /restore respectively.

We'll copy that here - massdriver-cloud sets up the cli, then you can use massdriver-cloud/image_push etc.