### PR TITLE
Change Root Action Name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,17 +1,17 @@
-name: 'Massdriver'
+name: 'Massdriver Actions'
 description: |
-  Set up the Massdriver CLI.
+  Build, push, publish, patch, and deploy your Massdriver applications.
 author: 'Massdriver, Inc.'
 inputs:
   tag:
     description: |
-      The release tag to fetch. Can be either a tag like `1.0.0` or `latest`.
+      The release tag to fetch. Can be either a tag like `1.2.0` or `latest`.
       Releases can be found at https://github.com/massdriver-cloud/mass.
     required: false
     default: 'latest'
   token:
     description: |
-      The GitHub token used to fetch a release. This is set by GitHub Actions.'
+      The GitHub token used to fetch a release. Set automatically by GitHub Actions.
     required: false
     default: ${{ github.token }}
 runs:


### PR DESCRIPTION
We can't have the same name as an org, so "Massdriver Actions" it is.

The description will show up in the GHA Marketplace, so we want to indicate that you can do more with these actions than just the "setup" action.