### PR TITLE
dependabot: ignore patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,4 +10,5 @@ updates:
     schedule:
       interval: weekly
     ignore:
-    - update-types: ["version-update:semver-patch"]
+    - dependency-name: "*"
+      update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
It's about a part time job's worth to keep up with every PATCH that npm throws our way.

Let's ignore PATCH updates for now, but still do MINOR