### PR TITLE
Support goreleaser

### DIFF
--- a/dist/setup/index.js
+++ b/dist/setup/index.js
@@ -18340,7 +18340,14 @@ const determineFile = (tag) => {
     const osPlatform = os.platform();
     // we publish arm64 and amd64 binaries
     const osArch = determineArch();
-    return `mass-${tag}-${osPlatform}-${osArch}.tar.gz`;
+    // After that tag we moved to goreleaser for github.com/massdriver-cloud/mass,
+    // which uses _ instead of -.
+    if (tag > '1.4.1') {
+        return `mass_${tag}_${osPlatform}_${osArch}.tar.gz`;
+    }
+    else {
+        return `mass-${tag}-${osPlatform}-${osArch}.tar.gz`;
+    }
 };
 exports.determineFile = determineFile;
 const filterByFileName = (file) => (asset) => file === asset.name;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -15,7 +15,14 @@ const determineFile = (tag: string): string => {
   const osPlatform = os.platform()
   // we publish arm64 and amd64 binaries
   const osArch = determineArch()
-  return `mass-${tag}-${osPlatform}-${osArch}.tar.gz`
+
+  // After that tag we moved to goreleaser for github.com/massdriver-cloud/mass,
+  // which uses _ instead of -.
+  if (tag > '1.4.1') {
+    return `mass_${tag}_${osPlatform}_${osArch}.tar.gz`
+  } else {
+    return `mass-${tag}-${osPlatform}-${osArch}.tar.gz`
+  }
 }
 
 const filterByFileName = (file: string) => (asset: Asset) => file === asset.name


### PR DESCRIPTION
For tags > 1.4.1, the CLI is switching releases to goreleaser, which
names assets with underscores instead of dashes.

Depending on what "latest" resolves to, we construct the file string
with either _ or -.