### PR TITLE
Add support for Skip Build

### DIFF
--- a/image_push/action.yml
+++ b/image_push/action.yml
@@ -49,6 +49,12 @@ inputs:
       Defaults to `Dockerfile`.
     required: false
     default: 'Dockerfile'
+  skip-build:
+    description: |
+      Skip building the image via mass. An image must be built by a previous action.
+      Defaults to `false`.
+    required: false
+    default: false
 runs:
   using: 'node16'
   main: '../dist/image_push/index.js'

--- a/image_push/action.yml
+++ b/image_push/action.yml
@@ -54,7 +54,7 @@ inputs:
       Skip building the image via mass. An image must be built by a previous action.
       Defaults to `false`.
     required: false
-    default: false
+    default: 'false'
 runs:
   using: 'node16'
   main: '../dist/image_push/index.js'

--- a/src/image_push.ts
+++ b/src/image_push.ts
@@ -10,6 +10,7 @@ const run = async (): Promise<void> => {
   const imageTags = core.getMultilineInput("image-tags", {required: false})
   const buildContext = core.getInput("build-context", {required: false})
   const dockerfile = core.getInput("dockerfile", {required: false})
+  const skipBuild = core.getBooleanInput("skip-build", {required: false})
 
   try {
     const command = `mass image push ${namespace}/${imageName}`
@@ -22,7 +23,9 @@ const run = async (): Promise<void> => {
       `--build-context`,
       buildContext,
       `--dockerfile`,
-      dockerfile
+      dockerfile,
+      `--skip-build`,
+      skipBuild.toString()
     ]
     
     const tags = imageTag.length > 0 ? [imageTag] : imageTags

--- a/src/image_push.ts
+++ b/src/image_push.ts
@@ -10,7 +10,7 @@ const run = async (): Promise<void> => {
   const imageTags = core.getMultilineInput("image-tags", {required: false})
   const buildContext = core.getInput("build-context", {required: false})
   const dockerfile = core.getInput("dockerfile", {required: false})
-  const skipBuild = core.getBooleanInput("skip-build", {required: false})
+  const skipBuild = core.getInput("skip-build", {required: false})
 
   try {
     const command = `mass image push ${namespace}/${imageName}`
@@ -25,7 +25,7 @@ const run = async (): Promise<void> => {
       `--dockerfile`,
       dockerfile,
       `--skip-build`,
-      skipBuild.toString()
+      skipBuild
     ]
     
     const tags = imageTag.length > 0 ? [imageTag] : imageTags


### PR DESCRIPTION
This PR supports the new CLI arg in the mass cli 

https://github.com/massdriver-cloud/mass/pull/108

I've added the skip-build using `get-input` there is a RFC commit asking whether it should be that or using `get-booleaninput`